### PR TITLE
Support multi point version name.

### DIFF
--- a/plugin/src/main/groovy/se/centril/robospock/RoboSpockAction.groovy
+++ b/plugin/src/main/groovy/se/centril/robospock/RoboSpockAction.groovy
@@ -60,7 +60,7 @@ class RoboSpockAction implements Action<RoboSpockConfiguration> {
 	private static void checkGradleVersion( RoboSpockConfiguration cfg ) {
 		// Check gradle version, ensure >= 2.2.
 		def v = cfg.perspective.gradle.gradleVersion
-		if ( v.toFloat() < 2.2 ) {
+		if ( "2.2".compareTo(v) > 0 ) {
 			throw new GradleException( "RoboSpock requires gradle >= 2.2, but current is: $v" )
 		}
 	}


### PR DESCRIPTION
Hi, this plugin is awesome.

But it doesn’t work in the following environments.
- Android Studio 1.0.0
- `com.android.tools.build:gradle:1.0.0`
- gradle 2.2.1 (gradle plugin 1.0.0 required gradle 2.2.1 or later.)

I faced error below.

`Error:(25, 0) Cause: multiple points`

The cause of this error is judgement of gradle version on `RoboSpockAction.groovy`.
I try to fix it.

thanks.
