### PR TITLE
Allow loading of transitive dependencies (Fix for #15)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
 		strictCheck = true
 		ignoreFailures = false
 		useDefaultMappings = true
-		ext.year = '2014'
+		ext.year = '2015'
 	}
 }
 

--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -26,6 +26,6 @@ dependencies {
 	classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.+'
 	classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
 
-	classpath 'com.android.tools.build:gradle:0.14.+'
+	classpath 'com.android.tools.build:gradle:1.0.+'
 	classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 group		= se.centril.robospock
-version		= 1.0.2-SNAPSHOT
+version		= 1.0.1
 projname	= gradle-plugin-robospock
 projdesc	= gradle plugin for configuring robospock (gradle + spock + roboelectric) easily.
 gitrepo		= centril/gradle-plugin-robospock
 
-#org.gradle.daemon	=	true
-#org.gradle.parallel	=	true
+org.gradle.daemon	=	true
+org.gradle.parallel	=	true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 group		= se.centril.robospock
-version		= 1.0.1
+version		= 1.0.2-SNAPSHOT
 projname	= gradle-plugin-robospock
 projdesc	= gradle plugin for configuring robospock (gradle + spock + roboelectric) easily.
 gitrepo		= centril/gradle-plugin-robospock
 
-org.gradle.daemon	=	true
-org.gradle.parallel	=	true
+#org.gradle.daemon	=	true
+#org.gradle.parallel	=	true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 19 05:45:57 CET 2014
+#Wed Dec 31 16:22:22 CST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip

--- a/plugin/src/main/groovy/se/centril/robospock/RoboSpockConfigurator.groovy
+++ b/plugin/src/main/groovy/se/centril/robospock/RoboSpockConfigurator.groovy
@@ -236,61 +236,13 @@ class RoboSpockConfigurator {
 	def copyAndroidDependencies() {
 		def tester = cfg.tester
 		def android = cfg.android
-		def projDep = getSubprojects( android ) + android
 
-		def zip2jarDependsTask = "compile${cfg.buildType.capitalize()}Java"
+		def dependencies = android.configurations.compile.dependencies
 
-		// Filter out duplicates due to project dependencies
-		projDep.unique().each { proj ->
-			def libsPath = new File( android.buildDir, 'libs' )
-			def aarPath = new File( android.buildDir, 'intermediates/exploded-aar/' )
-
-			// Create zip2jar task & make compileJava depend on it.
-			Task zip2jar = proj.tasks.create( name: ZIP_2_JAR_TASK, type: Zip ) {
-				dependsOn zip2jarDependsTask
-				description ZIP_2_JAR_DESCRIPTION
-				from new File( android.buildDir, "intermediates/classes/${cfg.buildType}" )
-				destinationDir = libsPath
-				extension = "jar"
-			}
-			tester.tasks.compileTestJava.dependsOn( zip2jar )
-
-			// Add all jars frm zip2jar + exploded-aar:s to dependencies.
+		dependencies.each { dep ->
 			tester.dependencies {
-				testCompile tester.fileTree( dir: libsPath, include: "*.jar" )
-				testCompile tester.fileTree( dir: aarPath, include: ['*/*/*/*.jar'] )
-				testCompile tester.fileTree( dir: aarPath, include: ['*/*/*/*/*.jar'] )
+				compile dep
 			}
 		}
-	}
-
-	/**
-	 * Returns all sub projects to the android project.
-	 *
-	 * @param project the {@link org.gradle.api.Project}.
-	 * @return the sub{@link org.gradle.api.Project}s.
-	 */
-	def List<Project> getSubprojects( Project project ) {
-		def projects = []
-		extractSubprojects( project, projects )
-		return projects
-	}
-
-	/**
-	 * Recursively extracts all dependency-subprojects from project.
-	 *
-	 * @param libraryProject the library {@link Project} to search in.
-	 * @param projects the list of {@link Project}s to add to.
-	 * @return the sub{@link Project}s.
-	 */
-	def extractSubprojects( Project libraryProject, List<Project> projects ) {
-		Configuration compile = libraryProject.configurations.all.find { it.name == 'compile' }
-
-		def projDeps = compile.allDependencies
-				.findAll { it instanceof ProjectDependency }
-				.collect { ((ProjectDependency) it).dependencyProject }
-
-		projDeps.each { extractSubprojects( it, projects ) }
-		projects.addAll( projDeps )
 	}
 }

--- a/testing/app-test/src/test/groovy/com/example/TransitiveDependencySpecification.groovy
+++ b/testing/app-test/src/test/groovy/com/example/TransitiveDependencySpecification.groovy
@@ -1,0 +1,13 @@
+package com.example;
+
+import spock.lang.Specification
+
+class TransitiveDependencySpecification extends Specification {
+    def "should create TransitiveDependency"() {
+        when:
+        def x = new TransitiveDependency()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/testing/app/build.gradle
+++ b/testing/app/build.gradle
@@ -17,6 +17,10 @@
 ['android-sdk-manager', 'com.android.application']
 	.each { apply plugin: it }
 
+dependencies {
+	compile 'com.jakewharton.timber:timber:2.5.0'
+}
+
 android {
 	compileSdkVersion 20
 	buildToolsVersion "20"

--- a/testing/app/src/main/java/com/example/TransitiveDependency.java
+++ b/testing/app/src/main/java/com/example/TransitiveDependency.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import timber.log.Timber;
+
+public final class TransitiveDependency {
+    public TransitiveDependency() {
+        Class<?> c = Timber.class;
+    }
+}


### PR DESCRIPTION
- Updated RoboSpockConfigurator to be able to include transitive dependencies.
- Added tests for transitive dependencies.
- Updates to gradle/android build tools

Fix for #15 
